### PR TITLE
Link quebrado e parenteses não necessários editados

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,12 +42,12 @@
         {% if page.url == '/' %}
           <h3>Links de unidades, grupos ou setores da USP que produzem código aberto:</h3>
           <ul>
-            <li><a href="https://github.com/iagsti">https://github.com/iagsti)</a></li>
-            <li><a href="https://github.com/fflch">https://github.com/fflch)</a></li>
+            <li><a href="https://github.com/iagsti">https://github.com/iagsti</a></li>
+            <li><a href="https://github.com/fflch">https://github.com/fflch</a></li>
             <li><a href="https://github.com/SIBiUSP">https://github.com/SIBiUSP</a></li>
-            <li><a href="https://github.com/uspcodelab">https://github.com/uspcodelab)</a></li>
-            <li><a href="Hardware Livre USP">https://github.com/HardwareLivreUSP)</a></li>
-            <li><a href="https://github.com/redelinux-ime-usp">https://github.com/redelinux-ime-usp)</a></li>
+            <li><a href="https://github.com/uspcodelab">https://github.com/uspcodelab</a></li>
+            <li><a href="https://github.com/HardwareLivreUSP">https://github.com/HardwareLivreUSP</a></li>
+            <li><a href="https://github.com/redelinux-ime-usp">https://github.com/redelinux-ime-usp</a></li>
           </ul>
         {% endif %}       
       </footer>


### PR DESCRIPTION
Link para Hardware Livre USP agora aponta para o github.
Parenteses aparentemente copiados por engano foram removidos